### PR TITLE
docs更新時とdocs以外更新時の条件付きworkflow追加

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
 
 concurrency: ${{ github.workflow }}
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -1,4 +1,4 @@
-name: docs-update
+name: conditional-check
 
 on:
   push:
@@ -13,8 +13,8 @@ on:
 concurrency: ${{ github.workflow }}
 
 jobs:
-  docs:
-    name: Docs Update
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -1,0 +1,22 @@
+name: docs-update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  docs:
+    name: Docs Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Docs updated
+        run: echo "Docs directory has been updated"
+

--- a/.github/workflows/non-docs-update.yml
+++ b/.github/workflows/non-docs-update.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 concurrency: ${{ github.workflow }}
 

--- a/.github/workflows/non-docs-update.yml
+++ b/.github/workflows/non-docs-update.yml
@@ -1,4 +1,4 @@
-name: non-docs-update
+name: conditional-check
 
 on:
   push:
@@ -13,8 +13,8 @@ on:
 concurrency: ${{ github.workflow }}
 
 jobs:
-  non-docs:
-    name: Non-Docs Update
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/non-docs-update.yml
+++ b/.github/workflows/non-docs-update.yml
@@ -1,0 +1,22 @@
+name: non-docs-update
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  non-docs:
+    name: Non-Docs Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Non-docs files updated
+        run: echo "Files other than docs have been updated"
+


### PR DESCRIPTION
## 概要
docsディレクトリが更新された場合と、docs以外が更新された場合にそれぞれ実行される条件付きworkflowを追加しました。

## 変更内容
- docsディレクトリが更新された場合のみ実行されるworkflow（docs-update.yml）を追加
- docsディレクトリ以外が更新された場合に実行されるworkflow（non-docs-update.yml）を追加
- PR作成時にもworkflowが実行されるようにpull_requestイベントを追加
- branch protection ruleで同じステータスチェックとして扱われるように、両方のworkflowで同じworkflow名とジョブ名を使用

## 動作確認
- mainブランチへのpush時に、変更内容に応じて適切なworkflowが実行されます
- PR作成時にも、変更内容に応じて適切なworkflowが実行されます
- branch protection ruleでは「Check」という1つのステータスチェックとして設定できます